### PR TITLE
Option to apply Slow Falling on disable flight

### DIFF
--- a/src/main/java/com/vice/balancedflight/content/flightAnchor/FlightController.java
+++ b/src/main/java/com/vice/balancedflight/content/flightAnchor/FlightController.java
@@ -23,7 +23,8 @@ public class FlightController
                 {
                     stopFlying(player);
                     // handle falling out of sky
-                    player.addEffect(new MobEffectInstance(MobEffects.SLOW_FALLING, 200));
+                    if (BalancedFlightConfig.applySlowFalling.get())
+                        player.addEffect(new MobEffectInstance(MobEffects.SLOW_FALLING, 200));
                 }
             }
             case Creative, Both -> {
@@ -31,7 +32,7 @@ public class FlightController
                 if (!player.getAbilities().mayfly) {
                     startFlying(player);
                     // handle removing effect cleanly
-                    if (player.hasEffect(MobEffects.SLOW_FALLING))
+                    if (player.hasEffect(MobEffects.SLOW_FALLING) && BalancedFlightConfig.applySlowFalling.get())
                         player.removeEffect(MobEffects.SLOW_FALLING);
                 }
             }

--- a/src/main/java/com/vice/balancedflight/foundation/config/BalancedFlightConfig.java
+++ b/src/main/java/com/vice/balancedflight/foundation/config/BalancedFlightConfig.java
@@ -13,6 +13,7 @@ public class BalancedFlightConfig
 {
     public static ForgeConfigSpec ConfigSpec;
 
+    public static ConfigValue<Boolean> applySlowFalling;
     public static ConfigValue<Boolean> enableElytraFlightFromGround;
     public static ConfigValue<Boolean> enableTakeOff;
     public static ConfigValue<Boolean> infiniteRockets;
@@ -43,6 +44,7 @@ public class BalancedFlightConfig
 
         builder.Block("Balancing Config", b -> {
             anchorDistanceMultiplier = b.defineInRange("Anchor Distance Multiplier (0d -> 10d, default 1d)", 1.0d, 0.0d, 10.0d);
+            applySlowFalling = b.define("Apply Slow Falling Effect When Removing Flight", true);
             disableFallDamageWhenWearingRing = b.define("Disable Fall Damage When Wearing Ascended Ring", true);
             disableFallDamageNearAnchor = b.define("Disable Fall Damage Near Flight Anchor", true);
         });


### PR DESCRIPTION
Currently, there is a bug that permanently applies the Slow Falling effect in certain situations with other mods (see #16)

Therefore, I've added a configuration option so server owners can disable the Slow Falling effect added on every tick. The mod will still disable flight, but it will not inflict the Slow Falling potion effect.

Tested on my own server running FTB Unstable 1.20 v1.5.0